### PR TITLE
fix  "[alacritty_config_derive] Config warning"

### DIFF
--- a/Rises/Hyprland/Hyprland_27-04-2022/.config/alacritty/alacritty.yml
+++ b/Rises/Hyprland/Hyprland_27-04-2022/.config/alacritty/alacritty.yml
@@ -57,7 +57,7 @@ colors:
     focus_match:
       foreground: '#000000'
       background: '#E040FB'
-    bar:
+    color.footer_bar:
       foreground: '#B388FF'
       background: '#121212'
   selection:


### PR DESCRIPTION
[79.184710665s] [WARN ] [alacritty_config_derive] Config warning: bar has been deprecated; use `colors.footer_bar` instead. 
![image](https://user-images.githubusercontent.com/109201315/217578699-2662b049-b535-4986-8432-03dc5834b42e.png)
